### PR TITLE
Fix bug on mobile sub navigation

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -12,7 +12,7 @@
       </div>
     </div>
 
-    <c-navigation slot="sub" v-bind:caption="parent.name" :active="active.children ? true : false" v-bind:target="active.path">
+    <c-navigation slot="sub" v-bind:caption="parent.name" :active="active.children ? true : false" v-bind:target="'#' + active.path">
       <router-link
         slot="primary-items"
         v-for="(item, index) in active.children"


### PR DESCRIPTION
To make it work in mobile view, subnavigation target should have exactly the same pattern as router link href